### PR TITLE
refactor: switch to gitlab hosting

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,8 +2,15 @@
 
 set -euo pipefail
 
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=../lib/versions.bash
+source "${plugin_dir}/lib/versions.bash"
+
 # TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for glab.
 GH_REPO="https://github.com/profclems/glab"
+GL_REPO="https://gitlab.com/gitlab-org/cli"
 TOOL_NAME="glab"
 TOOL_TEST="glab version"
 
@@ -24,27 +31,44 @@ sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-list_github_tags() {
-  git ls-remote --tags --refs "$GH_REPO" |
+list_tags() {
+  local all_tags github_tags gitlab_tags
+
+  github_tags="$(git ls-remote --tags --refs "$GH_REPO" |
     grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+    sed 's/^v//')"
+
+  gitlab_tags="$(git ls-remote --tags --refs "${GL_REPO}.git" |
+    grep -o 'refs/tags/.*' | cut -d/ -f3- |
+    sed 's/^v//')"
+
+  # some tags overlap between github and gitlab, so dedup them
+  all_tags=$(printf "%s\n%s" "$github_tags" "$gitlab_tags" | sort | uniq)
+
+  echo "$all_tags"
 }
 
 list_all_versions() {
   # TODO: Adapt this. By default we simply list the tag names from GitHub releases.
   # Change this function if glab has other means of determining installable versions.
-  list_github_tags
+  list_tags
 }
 
 download_release() {
-  local version filename url os arch
+  local version filename url os arch cutoff_version compare_result
   version="$1"
   filename="$2"
   os=$(get_os)
   arch=$(get_arch)
+  cutoff_version="1.23.0"
 
-  # TODO: Adapt the release URL convention for glab
-  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_${os}_${arch}.tar.gz"
+  # download from github if prior to version $cutoff_version
+  compare_versions "$version" "$cutoff_version" || compare_result=$?
+  if [ $compare_result -eq 1 ]; then # 1 = less, 2 = equal, 3 = greater
+    url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_${os}_${arch}.tar.gz"
+  else
+    url="$GL_REPO/-/releases/v${version}/downloads/${TOOL_NAME}_${version}_${os}_${arch}.tar.gz"
+  fi
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
@@ -79,12 +103,12 @@ get_os() {
   local os=$(uname)
 
   case $os in
-    Darwin)
-      echo macOS
-      ;;
-    *)
-      echo $os
-      ;;
+  Darwin)
+    echo macOS
+    ;;
+  *)
+    echo $os
+    ;;
   esac
 }
 
@@ -92,11 +116,11 @@ get_arch() {
   local arch=$(uname -m)
 
   case $arch in
-    *86)
-      echo i386
-      ;;
-    *)
-      echo $arch
-      ;;
+  *86)
+    echo i386
+    ;;
+  *)
+    echo $arch
+    ;;
   esac
 }

--- a/lib/versions.bash
+++ b/lib/versions.bash
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Compares two dot-delimited decimal-element version numbers a and b that may
+# also have arbitrary string suffixes. Compatible with semantic versioning, but
+# not as strict: comparisons of non-semver strings may have unexpected
+# behavior.
+#
+# Returns:
+# 1 if a<b
+# 2 if equal
+# 3 if a>b
+compare_versions() {
+  local LC_ALL=C
+
+  # Optimization
+  if [[ $1 == "$2" ]]; then
+    return 2
+  fi
+
+  # Compare numeric release versions. Supports an arbitrary number of numeric
+  # elements (i.e., not just X.Y.Z) in which unspecified indices are regarded
+  # as 0.
+  local aver=${1%%[^0-9.]*} bver=${2%%[^0-9.]*}
+  local arem=${1#$aver} brem=${2#$bver}
+  local IFS=.
+  # shellcheck disable=SC2206
+  local i a=($aver) b=($bver)
+  for ((i = 0; i < ${#a[@]} || i < ${#b[@]}; i++)); do
+    if ((10#${a[i]:-0} < 10#${b[i]:-0})); then
+      return 1
+    elif ((10#${a[i]:-0} > 10#${b[i]:-0})); then
+      return 3
+    fi
+  done
+
+  # Remove build metadata before remaining comparison
+  arem=${arem%%+*}
+  brem=${brem%%+*}
+
+  # Prelease (w/remainder) always older than release (no remainder)
+  if [ -n "$arem" ] && [ -z "$brem" ]; then
+    return 1
+  elif [ -z "$arem" ] && [ -n "$brem" ]; then
+    return 3
+  fi
+
+  # Otherwise, split by periods and compare individual elements either
+  # numerically or lexicographically
+  # shellcheck disable=SC2206
+  local a=(${arem#-}) b=(${brem#-})
+  for ((i = 0; i < ${#a[@]} && i < ${#b[@]}; i++)); do
+    local anns=${a[i]#${a[i]%%[^0-9]*}} bnns=${b[i]#${b[i]%%[^0-9]*}}
+    if [ -z "$anns$bnns" ]; then
+      # Both numeric
+      if ((10#${a[i]:-0} < 10#${b[i]:-0})); then
+        return 1
+      elif ((10#${a[i]:-0} > 10#${b[i]:-0})); then
+        return 3
+      fi
+    elif [ -z "$anns" ]; then
+      # Numeric comes before non-numeric
+      return 1
+    elif [ -z "$bnns" ]; then
+      # Numeric comes before non-numeric
+      return 3
+    else
+      # Compare lexicographically
+      if [[ ${a[i]} < ${b[i]} ]]; then
+        return 1
+      elif [[ ${a[i]} > ${b[i]} ]]; then
+        return 3
+      fi
+    fi
+  done
+
+  # Fewer elements is earlier
+  if ((${#a[@]} < ${#b[@]})); then
+    return 1
+  elif ((${#a[@]} > ${#b[@]})); then
+    return 3
+  fi
+
+  # Must be equal!
+  return 2
+}


### PR DESCRIPTION
Versions 1.23.0 and later are now hosted on GitLab, so added code to
download those releases from the new location.
