### PR TITLE
fix: translate aarch64 to arm64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -119,8 +119,9 @@ get_arch() {
   *86)
     echo i386
     ;;
-  *aarch64)
+  aarch64)
     echo arm64
+    ;;
   *)
     echo $arch
     ;;

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -119,6 +119,8 @@ get_arch() {
   *86)
     echo i386
     ;;
+  *aarch64)
+    echo arm64
   *)
     echo $arch
     ;;


### PR DESCRIPTION
Tried this plugin with [Mise](https://github.com/jdx/mise) on [Asahi Ubuntu](https://ubuntuasahi.org/) where `uname -m` gives `aarch64` back. However on the GitLab Releases page we can see that in expects `arm64`: 
![image](https://github.com/particledecay/asdf-glab/assets/17970041/eda0d277-1b74-4fb3-af67-d5b9e7bfd134)
[source](https://gitlab.com/gitlab-org/cli/-/releases/v1.36.0)