### PR TITLE
fix: adjust downloads to align with new package names introduced

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -104,7 +104,13 @@ get_os() {
 
   case $os in
   Darwin)
-    echo macOS
+    echo darwin
+    ;;
+  Linux)
+    echo linux
+    ;;
+  Windows)
+    echo windows
     ;;
   *)
     echo $os
@@ -117,11 +123,15 @@ get_arch() {
 
   case $arch in
   *86)
-    echo i386
+    echo 386
     ;;
   aarch64)
     echo arm64
     ;;
+  x86_64)
+    echo amd64
+    ;;
+
   *)
     echo $arch
     ;;


### PR DESCRIPTION
A new schema to name the packages for the gitlab-cli tool was introduced in https://gitlab.com/gitlab-org/cli/-/merge_requests/1701, and this MR makes sure to download the correct archive.

Fixes https://github.com/particledecay/asdf-glab/issues/10